### PR TITLE
Fix autoupdate by setting full emojibase-data tag

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -57,6 +57,7 @@ ram.runtime = "15M"
     sha256 = "9d4f5509d1ae917b48c147f962a5309d6b74833ae24193443d5200609da7f4ad"
     autoupdate.upstream = "https://github.com/milesj/emojibase"
     autoupdate.strategy = "latest_github_release"
+    autoupdate.version_regex = "^emojibase-data@(.*)$"
     
     [resources.system_user]
 


### PR DESCRIPTION
This PR aims at fixing the following fail status after [autoupdate_app_sources.py](https://github.com/YunoHost/apps_tools/blob/main/autoupdate_app_sources/autoupdate_app_sources.py) is run on the YNH infra:

```
pinkarrows
----------------------------------------

  Checking main ...
Current version in manifest: 1.0
Newest  version on upstream: 2024.08.23
Update needed for main
Computing sha256sum for https://github.com/robbalian/pinkarrows/archive/bd673c14cd2a069fdfd1bcf592ebaee1d7222f6b.tar.gz ...

  Checking emojibase ...
Ignoring tag website@2.3.2, doesn't look like a version number
Ignoring tag emojibase-test-utils@15.2.2, doesn't look like a version number
Ignoring tag emojibase-regex@15.3.2, doesn't look like a version number
Ignoring tag emojibase-generator@15.3.2, doesn't look like a version number
Ignoring tag emojibase-data@15.3.2, doesn't look like a version number
Ignoring tag website@2.3.1, doesn't look like a version number
Ignoring tag emojibase@15.3.1, doesn't look like a version number
Ignoring tag emojibase-test-utils@15.2.1, doesn't look like a version number
Ignoring tag emojibase-regex@15.3.1, doesn't look like a version number
Ignoring tag emojibase-generator@15.3.1, doesn't look like a version number
Ignoring tag emojibase-data@15.3.1, doesn't look like a version number
Ignoring tag website@2.3.0, doesn't look like a version number
Ignoring tag emojibase@15.3.0, doesn't look like a version number
Ignoring tag emojibase-test-utils@15.2.0, doesn't look like a version number
Ignoring tag emojibase-regex@15.3.0, doesn't look like a version number
Ignoring tag emojibase-generator@15.3.0, doesn't look like a version number
Ignoring tag emojibase-data@15.3.0, doesn't look like a version number
Ignoring tag website@2.2.0, doesn't look like a version number
Ignoring tag emojibase@15.2.0, doesn't look like a version number
Ignoring tag emojibase-regex@15.2.0, doesn't look like a version number
Ignoring tag emojibase-generator@15.2.0, doesn't look like a version number
Ignoring tag emojibase-data@15.2.0, doesn't look like a version number
Ignoring tag website@2.1.0, doesn't look like a version number
Ignoring tag emojibase@15.1.0, doesn't look like a version number
Ignoring tag emojibase-test-utils@15.1.0, doesn't look like a version number
Ignoring tag emojibase-regex@15.1.0, doesn't look like a version number
Ignoring tag emojibase-generator@15.1.0, doesn't look like a version number
Ignoring tag emojibase-data@15.1.0, doesn't look like a version number
Ignoring tag website@2.0.0, doesn't look like a version number
Ignoring tag emojibase@15.0.0, doesn't look like a version number
Ignoring tag emojibase-test-utils@15.0.0, doesn't look like a version number
Ignoring tag emojibase-regex@15.0.0, doesn't look like a version number
Ignoring tag emojibase-generator@15.0.0, doesn't look like a version number
Ignoring tag emojibase-data@15.0.0, doesn't look like a version number

Traceback (most recent call last):
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/autoupdate_app_sources.py", line 691, in run_autoupdate_for_multiprocessing
    result = autoupdater.run(edit=edit, commit=commit, pr=pr)
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/autoupdate_app_sources.py", line 225, in run
    update = self.get_source_update(source, infos)
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/autoupdate_app_sources.py", line 385, in get_source_update
    result = self.get_latest_version_and_asset(strategy, asset, infos)
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/autoupdate_app_sources.py", line 483, in get_latest_version_and_asset
    latest_version_orig, latest_version = self.relevant_versions(
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/autoupdate_app_sources.py", line 344, in relevant_versions
    raise RuntimeError("No tags were found after sanity filtering!")
RuntimeError: No tags were found after sanity filtering!
```

